### PR TITLE
Don't crash on ASGs with MixedInstancesPolicy type ASGs

### DIFF
--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -11,23 +11,25 @@ from .resources.models import AMI
 
 class Fetcher(object):
 
-    """ Fetches function for AMI candidates to deletion """
+    """Fetches function for AMI candidates to deletion"""
 
     def __init__(self, ec2=None, autoscaling=None):
 
-        """ Initializes aws sdk clients """
+        """Initializes aws sdk clients"""
 
-        self.ec2 = ec2 or boto3.client('ec2', config=Config(retries={'max_attempts': BOTO3_RETRIES}))
-        self.asg = autoscaling or boto3.client('autoscaling')
+        self.ec2 = ec2 or boto3.client(
+            "ec2", config=Config(retries={"max_attempts": BOTO3_RETRIES})
+        )
+        self.asg = autoscaling or boto3.client("autoscaling")
 
     def fetch_available_amis(self):
 
-        """ Retrieve from your aws account your custom AMIs"""
+        """Retrieve from your aws account your custom AMIs"""
 
         available_amis = dict()
 
-        my_custom_images = self.ec2.describe_images(Owners=['self'])
-        for image_json in my_custom_images.get('Images'):
+        my_custom_images = self.ec2.describe_images(Owners=["self"])
+        for image_json in my_custom_images.get("Images"):
             ami = AMI.object_with_json(image_json)
             available_amis[ami.id] = ami
 
@@ -41,12 +43,16 @@ class Fetcher(object):
         """
 
         resp = self.asg.describe_auto_scaling_groups()
-        used_lc = (asg.get("LaunchConfigurationName", "")
-                   for asg in resp.get("AutoScalingGroups", []))
+        used_lc = (
+            asg.get("LaunchConfigurationName", "")
+            for asg in resp.get("AutoScalingGroups", [])
+        )
 
         resp = self.asg.describe_launch_configurations()
-        all_lcs = (lc.get("LaunchConfigurationName", "")
-                   for lc in resp.get("LaunchConfigurations", []))
+        all_lcs = (
+            lc.get("LaunchConfigurationName", "")
+            for lc in resp.get("LaunchConfigurations", [])
+        )
 
         unused_lcs = list(set(all_lcs) - set(used_lc))
 
@@ -54,9 +60,7 @@ class Fetcher(object):
             LaunchConfigurationNames=unused_lcs
         )
 
-        amis = [lc.get("ImageId")
-                for lc in resp.get("LaunchConfigurations", [])]
-
+        amis = [lc.get("ImageId") for lc in resp.get("LaunchConfigurations", [])]
 
         return amis
 
@@ -68,12 +72,15 @@ class Fetcher(object):
         """
 
         resp = self.asg.describe_auto_scaling_groups()
-        used_lt = (asg.get("LaunchTemplate", {}).get("LaunchTemplateName")
-                   for asg in resp.get("AutoScalingGroups", []))
+        used_lt = (
+            asg.get("LaunchTemplate", {}).get("LaunchTemplateName")
+            for asg in resp.get("AutoScalingGroups", [])
+        )
 
         resp = self.ec2.describe_launch_templates()
-        all_lts = (lt.get("LaunchTemplateName", "")
-                   for lt in resp.get("LaunchTemplates", []))
+        all_lts = (
+            lt.get("LaunchTemplateName", "") for lt in resp.get("LaunchTemplates", [])
+        )
 
         unused_lts = list(set(all_lts) - set(used_lt))
 
@@ -82,8 +89,10 @@ class Fetcher(object):
             resp = self.ec2.describe_launch_template_versions(
                 LaunchTemplateName=lt_name
             )
-            amis.append(lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
-                        for lt_latest_version in resp.get("LaunchTemplateVersions", []))
+            amis.append(
+                lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
+                for lt_latest_version in resp.get("LaunchTemplateVersions", [])
+            )
 
         return amis
 
@@ -94,16 +103,18 @@ class Fetcher(object):
         """
 
         resp = self.asg.describe_auto_scaling_groups()
-        zeroed_lcs = [asg.get("LaunchConfigurationName", "")
-                      for asg in resp.get("AutoScalingGroups", [])
-                      if asg.get("DesiredCapacity", 0) == 0 and len(asg.get("LaunchConfigurationNames", [])) > 0]
+        zeroed_lcs = [
+            asg.get("LaunchConfigurationName", "")
+            for asg in resp.get("AutoScalingGroups", [])
+            if asg.get("DesiredCapacity", 0) == 0
+            and len(asg.get("LaunchConfigurationNames", [])) > 0
+        ]
 
         resp = self.asg.describe_launch_configurations(
             LaunchConfigurationNames=zeroed_lcs
         )
 
-        amis = [lc.get("ImageId", "")
-                for lc in resp.get("LaunchConfigurations", [])]
+        amis = [lc.get("ImageId", "") for lc in resp.get("LaunchConfigurations", [])]
 
         return amis
 
@@ -115,51 +126,88 @@ class Fetcher(object):
 
         resp = self.asg.describe_auto_scaling_groups()
         # This does not support multiple versions of the same launch template being used
-        zeroed_lts = [asg.get("LaunchTemplate", {})
-                      for asg in resp.get("AutoScalingGroups", [])
-                      if asg.get("DesiredCapacity", 0) == 0]
+        zeroed_lts = [
+            self.getLaunchTemplate(asg)
+            for asg in resp.get("AutoScalingGroups", [])
+            if asg.get("DesiredCapacity", 0) == 0
+        ]
 
-        zeroed_lt_names = [lt.get("LaunchTemplateName", "")
-                        for lt in zeroed_lts]
+        zeroed_lt_names = [self.getLaunchTemplateName(lt) for lt in zeroed_lts]
 
-        zeroed_lt_versions = [lt.get("LaunchTemplateVersion", "")
-                        for lt in zeroed_lts]
+        zeroed_lt_versions = [self.getLaunchTemplateVersion(lt) for lt in zeroed_lts]
 
-        resp = self.ec2.describe_launch_templates(
-            LaunchTemplateNames=zeroed_lt_names
-        )
+        resp = self.ec2.describe_launch_templates(LaunchTemplateNames=zeroed_lt_names)
 
         amis = []
         for lt_name, lt_version in zip(zeroed_lt_names, zeroed_lt_versions):
             resp = self.ec2.describe_launch_template_versions(
                 LaunchTemplateName=lt_name
-                # Cannot be empty... Versions=[lt_version] - unsure how to pass param only if present in Python 
+                # Cannot be empty... Versions=[lt_version] - unsure how to pass param only if present in Python
             )
-            amis.append(lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
-                        for lt_latest_version in resp.get("LaunchTemplateVersions", []))
+            amis.append(
+                lt_latest_version.get("LaunchTemplateData", {}).get("ImageId")
+                for lt_latest_version in resp.get("LaunchTemplateVersions", [])
+            )
 
         return amis
 
     def fetch_instances(self):
 
-        """ Find AMIs for not terminated EC2 instances """
+        """Find AMIs for not terminated EC2 instances"""
 
         resp = self.ec2.describe_instances(
             Filters=[
                 {
-                    'Name': 'instance-state-name',
-                    'Values': [
-                        'pending',
-                        'running',
-                        'shutting-down',
-                        'stopping',
-                        'stopped'
-                    ]
+                    "Name": "instance-state-name",
+                    "Values": [
+                        "pending",
+                        "running",
+                        "shutting-down",
+                        "stopping",
+                        "stopped",
+                    ],
                 }
             ]
         )
-        amis = [i.get("ImageId", None)
-                for r in resp.get("Reservations", [])
-                for i in r.get("Instances", [])]
+        amis = [
+            i.get("ImageId", None)
+            for r in resp.get("Reservations", [])
+            for i in r.get("Instances", [])
+        ]
 
         return amis
+
+    def getLaunchTemplate(self, asg):
+        """
+        ASGs can have launch templates in one of two places:
+        either asg["LaunchTemplate"] OR asg["MixedInstancePolicy"]["LaunchTemplate"] depending on
+        how the ASG is configured.
+        """
+        if asg.get("LaunchTemplate") != None:
+            return asg.get("LaunchTemplate")
+        elif asg.get("MixedInstancesPolicy").get("LaunchTemplate") != None:
+            return asg.get("MixedInstancesPolicy").get("LaunchTemplate")
+        else:
+            return {}
+
+    def getLaunchTemplateName(self, lt):
+        """
+        This also varies based on if the launch template was a MixedInstancePolicy one or not
+        """
+        if lt.get("LaunchTemplateName") != None:
+            return lt.get("LaunchTemplateName")
+        elif lt.get("LaunchTemplateSpecification").get("LaunchTemplateName") != None:
+            return lt.get("LaunchTemplateSpecification").get("LaunchTemplateName")
+        else:
+            return ""
+
+    def getLaunchTemplateVersion(self, lt):
+        """
+        This also varied based on the if the launch template was a MixedInstancePolicy one
+        """
+        if lt.get("LaunchTemplateVersion") != None:
+            return lt.get("LaunchTemplateVersion")
+        elif lt.get("LaunchTemplateSpecification").get("Version") != None:
+            return lt.get("LaunchTemplateSpecification").get("Version")
+        else:
+            return ""


### PR DESCRIPTION
I discovered a bug where, if run against ASGs that have MixedInstancesPolicies, the cleaner would crash:
![Screen Shot 2021-11-03 at 10 29 28](https://user-images.githubusercontent.com/397565/140029766-621ce109-7d68-4e71-9f54-a30845e59057.png)

To fix it in a way that (hopefully) preserves the existing behavior as well, I added functions that will first check for the "regular" launchtemplate info as before, then check for the mixedinstances-formatted info if it doesn't find the first. With these changes, we no longer fail on those same ASGs:
![Screen Shot 2021-11-03 at 10 28 05](https://user-images.githubusercontent.com/397565/140030052-22f6e1b3-e1fc-4d87-ba5d-54fbd144f44d.png)


